### PR TITLE
使用 Python 3.7 的 dataclasses 来解决序列化问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea/
+.venv/
+.vscode/
+
+*.DS_Store
+*.log*
+*.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/yuanfei/.local/share/virtualenvs/api-XD34dAIU/bin/python"
-}

--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,7 @@
 [[source]]
-url = "https://pypi.python.org/simple"
+url = "https://mirrors.aliyun.com/pypi/simple/"
 verify_ssl = true
-name = "pypi"
+name = "aliyun"
 
 [packages]
 flask = "*"
@@ -10,4 +10,4 @@ requests = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,16 +1,16 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "77dfdd6190ebeff01ebf543206b8adcc38d86ee72ea985659380da4315cbf472"
+            "sha256": "8aec575a0b5b0e05efcd49250ba5df06e4ec12f01a28c72d4bb1cb85e20c96cd"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
-                "name": "pypi",
-                "url": "https://pypi.python.org/simple",
+                "name": "aliyun",
+                "url": "https://mirrors.aliyun.com/pypi/simple/",
                 "verify_ssl": true
             }
         ]
@@ -84,6 +84,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.6'",
             "version": "==1.23"
         },
         "werkzeug": {

--- a/tielian/block.py
+++ b/tielian/block.py
@@ -1,12 +1,13 @@
 import hashlib
-from datetime import datetime
 import logging
-import time
 import sys
-from transaction import create_transaction_from_json
+import time
+from datetime import datetime
+
+from tielian.transaction import create_transaction_from_json
+
 
 class Block:
-
     # 难度 - 用区块哈希开头“0”的数量来标记
     # 例如，默认难度为2，那么合法哈希的开头就应该有两个0
     difficulty = 2
@@ -35,8 +36,8 @@ class Block:
         根据区块数据，生成唯一的区块哈希。哈希算法是最最简单的sha256。
         """
         sha = hashlib.sha256()
-        sig = "%s|%s|%s|%s|%s" % (
-            self.index, self.timestamp, self.data, 
+        sig = '%s|%s|%s|%s|%s' % (
+            self.index, self.timestamp, self.data,
             self.previous_hash, self.nonce
         )
 
@@ -57,12 +58,12 @@ class Block:
 
     def to_json(self):
         return {
-            "index": self.index,
-            "timestamp": self.timestamp,
-            "data": self.data,
-            "previous_hash": self.previous_hash,
-            "hash": self.hash,
-            "nonce": self.nonce
+            'index': self.index,
+            'timestamp': self.timestamp,
+            'data': self.data,
+            'previous_hash': self.previous_hash,
+            'hash': self.hash,
+            'nonce': self.nonce
         }
 
     def _validate_lineage(self, current_block):
@@ -70,13 +71,12 @@ class Block:
         验证区块传承性
         """
         if self.previous_hash != current_block.hash:
-            raise Exception('前序哈希值不匹配') # TODO: 定制异常类
+            raise Exception('前序哈希值不匹配')  # TODO: 定制异常类
 
         if self.index != current_block.index + 1:
             raise Exception('区块高度不匹配')
 
         return True
-
 
     def validate_difficulty(self):
         """
@@ -95,12 +95,14 @@ class Block:
         """
         return self._validate_lineage(current_block) and self.validate_difficulty()
 
+
 def create_genesis_block():
     """
     创建创始区块
     """
     now = int(datetime.now().timestamp())
-    return Block(0, now, "Skr! 我是创始区块!", "0", 0)
+    return Block(0, now, 'Skr! 我是创始区块!', '0', 0)
+
 
 def load_block(payload):
     """
@@ -113,8 +115,6 @@ def load_block(payload):
         payload['previous_hash'],
         payload['nonce']
     )
-    
-
 
 
 def new_block(last_block, data):
@@ -136,10 +136,10 @@ def run():
 
     while True:
         # 广播当前区块
-        logging.info("新区块<#%3d, h=%s>加入铁链：%s", current_block.index, current_block.hash, current_block.data)
+        logging.info('新区块<#%3d, h=%s>加入铁链：%s', current_block.index, current_block.hash, current_block.data)
 
         # 生成新区块
-        data = "你好，我是区块<#%d>" % (current_block.index + 1)
+        data = '你好，我是区块<#%d>' % (current_block.index + 1)
         pending_block = new_block(current_block, data)
 
         # 矿工挖矿🚧
@@ -154,15 +154,16 @@ def run():
 
         # [周而复始...↑]
 
+
 if __name__ == '__main__':
     # 配置日志，打到控制台上
     logging.basicConfig(level=logging.INFO)
 
     # 铁链甩起来！
-    logging.info("区块链？就是...铁链嘛！\n\n")
+    logging.info('区块链？就是...铁链嘛！\n\n')
 
     try:
         run()
     except KeyboardInterrupt:
-        logging.info("铁链断裂[-END-]")
+        logging.info('铁链断裂[-END-]')
         sys.exit(0)

--- a/tielian/block.py
+++ b/tielian/block.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import time
 
-from tielian.transaction import create_transaction_from_json
+from tielian.transaction import Transaction
 
 
 @dataclasses.dataclass
@@ -15,8 +15,8 @@ class Block:
     index: int
     # 时间戳
     timestamp: int
-    # 任意数据
-    data: str
+    # 任意字典数据
+    data: dict
     # 前一个区块的哈希值
     previous_hash: str
     # 神秘数字
@@ -39,7 +39,7 @@ class Block:
 
     @property
     def txs(self):
-        return map(lambda p: create_transaction_from_json(p), self.data['txs'])
+        return [Transaction(**payload) for payload in self.data.get('txs', [])]
 
     def to_json(self):
         return {**dataclasses.asdict(self), 'hash': self.hash}
@@ -71,7 +71,7 @@ def create_genesis_block():
     创建创始区块
     """
     now = int(time.time())
-    return Block(0, now, 'Skr! 我是创始区块!', '0', 0)
+    return Block(0, now, {'message': 'Skr! 我是创始区块!'}, '0', 0)
 
 
 def load_block(payload):

--- a/tielian/block.py
+++ b/tielian/block.py
@@ -61,9 +61,9 @@ class Block:
             raise Exception(f'难度不符，当前难度：{self.difficulty}，实际哈希前缀：{self.hash[:self.difficulty]}')
         return True
 
-    def is_valid(self, current_block):
+    def is_valid(self, previous_block: 'Block'):
         """ 验证区块是否合格 """
-        return self._validate_lineage(current_block) and self.validate_difficulty()
+        return self._validate_lineage(previous_block) and self.validate_difficulty()
 
 
 def create_genesis_block():

--- a/tielian/block.py
+++ b/tielian/block.py
@@ -74,19 +74,6 @@ def create_genesis_block():
     return Block(0, now, {'message': 'Skr! 我是创始区块!'}, '0', 0)
 
 
-def load_block(payload):
-    """
-    将 JSON 格式的新区块变成 Block 类型
-    """
-    return Block(
-        payload['index'],
-        payload['timestamp'],
-        payload['data'],
-        payload['previous_hash'],
-        payload['nonce']
-    )
-
-
 def new_block(last_block, data):
     """
     生成新区块，需要上一个区块的哈希值来连接铁链

--- a/tielian/block.py
+++ b/tielian/block.py
@@ -1,75 +1,51 @@
+import dataclasses
 import hashlib
 import logging
 import sys
 import time
-from datetime import datetime
 
 from tielian.transaction import create_transaction_from_json
 
 
+@dataclasses.dataclass
 class Block:
+    """ 一个区块 """
+
+    # 区块高度
+    index: int
+    # 时间戳
+    timestamp: int
+    # 任意数据
+    data: str
+    # 前一个区块的哈希值
+    previous_hash: str
+    # 神秘数字
+    nonce: int = 0
+
     # 难度 - 用区块哈希开头“0”的数量来标记
     # 例如，默认难度为2，那么合法哈希的开头就应该有两个0
     difficulty = 2
 
-    def __init__(self, _index, _timestamp, _data, _previous_hash, _nonce=0):
-        # 区块高度
-        self.index = _index
-
-        # 时间戳
-        self.timestamp = _timestamp
-
-        # Nonce - 神秘数字
-        self.nonce = _nonce
-
-        # 任意数据
-        self.data = _data
-
-        # 上一个区块哈希
-        self.previous_hash = _previous_hash
-
-        # 区块哈希
-        self.hash = self.calc_hash()
-
-    def calc_hash(self):
-        """
-        根据区块数据，生成唯一的区块哈希。哈希算法是最最简单的sha256。
-        """
+    @property
+    def hash(self):
+        """ 根据区块数据，生成唯一的区块哈希。哈希算法是最最简单的sha256。 """
         sha = hashlib.sha256()
-        sig = '%s|%s|%s|%s|%s' % (
-            self.index, self.timestamp, self.data,
-            self.previous_hash, self.nonce
-        )
+        sig = f'{self.index}|{self.timestamp}|{self.data}|{self.previous_hash}|{self.nonce}'
 
         # 因为数据(data)可能会有中文，这里用统一utf8编码
         sha.update(sig.encode('utf8'))
 
         return sha.hexdigest()
 
-    def update(self):
-        """
-        在参数（如nonce）改变的时候，更新hash
-        """
-        self.hash = self.calc_hash()
-
     @property
     def txs(self):
         return map(lambda p: create_transaction_from_json(p), self.data['txs'])
 
     def to_json(self):
-        return {
-            'index': self.index,
-            'timestamp': self.timestamp,
-            'data': self.data,
-            'previous_hash': self.previous_hash,
-            'hash': self.hash,
-            'nonce': self.nonce
-        }
+        return {**dataclasses.asdict(self), 'hash': self.hash}
 
     def _validate_lineage(self, current_block):
-        """
-        验证区块传承性
-        """
+        """ 验证区块传承性 """
         if self.previous_hash != current_block.hash:
             raise Exception('前序哈希值不匹配')  # TODO: 定制异常类
 
@@ -79,20 +55,14 @@ class Block:
         return True
 
     def validate_difficulty(self):
-        """
-        验证区块符合难度
-        """
+        """ 验证区块符合难度 """
         valid_padding = '0' * self.difficulty
         if not self.hash.startswith(valid_padding):
-            raise Exception('难度不符，当前难度：%s，实际哈希前缀：%s' % (
-                self.difficulty, self.hash[:self.difficulty]
-            ))
+            raise Exception(f'难度不符，当前难度：{self.difficulty}，实际哈希前缀：{self.hash[:self.difficulty]}')
         return True
 
     def is_valid(self, current_block):
-        """
-        验证区块是否合格
-        """
+        """ 验证区块是否合格 """
         return self._validate_lineage(current_block) and self.validate_difficulty()
 
 
@@ -100,7 +70,7 @@ def create_genesis_block():
     """
     创建创始区块
     """
-    now = int(datetime.now().timestamp())
+    now = int(time.time())
     return Block(0, now, 'Skr! 我是创始区块!', '0', 0)
 
 
@@ -122,9 +92,8 @@ def new_block(last_block, data):
     生成新区块，需要上一个区块的哈希值来连接铁链
     """
     index = last_block.index + 1
-    timestamp = datetime.now()
+    timestamp = int(time.time())
     previous_hash = last_block.hash
-
     return Block(index, timestamp, data, previous_hash)
 
 
@@ -139,7 +108,7 @@ def run():
         logging.info('新区块<#%3d, h=%s>加入铁链：%s', current_block.index, current_block.hash, current_block.data)
 
         # 生成新区块
-        data = '你好，我是区块<#%d>' % (current_block.index + 1)
+        data = f'你好，我是区块<#{current_block.index + 1:d}>'
         pending_block = new_block(current_block, data)
 
         # 矿工挖矿🚧
@@ -160,7 +129,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
     # 铁链甩起来！
-    logging.info('区块链？就是...铁链嘛！\n\n')
+    logging.info('区块链？就是...铁链嘛！\n')
 
     try:
         run()

--- a/tielian/miner.py
+++ b/tielian/miner.py
@@ -1,10 +1,11 @@
+import dataclasses
 import logging
-from datetime import datetime
+import time
 
 import requests
 
 from tielian.block import Block, load_block
-from tielian.transaction import create_transaction_from_json, dump_transactions
+from tielian.transaction import create_transaction_from_json
 
 
 class MiningJob:
@@ -17,12 +18,12 @@ class MiningJob:
         self.pending_txs = pending_txs
 
         data = {
-            "txs": dump_transactions(self.pending_txs)
+            'txs': [dataclasses.asdict(_) for _ in self.pending_txs],
         }
 
         self.block = Block(
             self.previous_block.index + 1,
-            datetime.now().timestamp,
+            int(time.time()),
             data,
             self.previous_block.hash,
             0

--- a/tielian/miner.py
+++ b/tielian/miner.py
@@ -1,8 +1,11 @@
-from block import Block, load_block
-from transaction import create_transaction_from_json, dump_transactions
 import logging
-import requests
 from datetime import datetime
+
+import requests
+
+from tielian.block import Block, load_block
+from tielian.transaction import create_transaction_from_json, dump_transactions
+
 
 class MiningJob:
     """
@@ -52,6 +55,7 @@ class MiningJob:
             self.block.update()
 
         return self.block
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/tielian/rpc.py
+++ b/tielian/rpc.py
@@ -1,22 +1,23 @@
-from flask import Flask, request, jsonify
-from transaction import create_transaction_from_json, trim_pending_txs
-from block import create_genesis_block, load_block
-
 import logging
 
+from flask import Flask, jsonify, request
 
-app = Flask("TIELIE_RPC_v1")
+from tielian.block import create_genesis_block, load_block
+from tielian.transaction import create_transaction_from_json, trim_pending_txs
+
+app = Flask('TIELIE_RPC_v1')
 
 # 待定交易列表，新提交的交易会被加入到该列表内
 pending_txs = []
 
 chain = [create_genesis_block()]
 
+
 @app.route('/txs', methods=['POST'])
 def submit_tx():
     """
     提交交易
-    
+
     交易将被加入到待打包交易
     """
     payload = request.get_json()
@@ -28,9 +29,10 @@ def submit_tx():
     logging.info('收到新交易：%s，当前待定交易数量：%d', tx, len(pending_txs))
 
     return jsonify(
-        result=tx.to_json(), 
-        msg="铁链本节点成功收到交易",
+        result=tx.to_json(),
+        msg='铁链本节点成功收到交易',
     ), 201
+
 
 @app.route('/txs', methods=['GET'])
 def get_pending_txs():
@@ -55,9 +57,10 @@ def submit_block():
 
     # 把已经打包的交易从待打包交易去掉
     pending_txs = trim_pending_txs(pending_txs, block)
-        
+
     chain.append(block)
     return "", 201
+
 
 @app.route('/blocks', methods=['GET'])
 def get_all_blocks():
@@ -67,14 +70,15 @@ def get_all_blocks():
     blocks = list(map(lambda x: x.to_json(), chain))
     return jsonify(blocks=blocks)
 
+
 @app.route('/blocks/latest', methods=['GET'])
 def get_latest_block():
     return jsonify(block=chain[-1].to_json())
 
+
 @app.errorhandler(Exception)
 def error_handler(e):
     return jsonify(msg=str(e)), 500
-
 
 
 if __name__ == '__main__':

--- a/tielian/rpc.py
+++ b/tielian/rpc.py
@@ -1,11 +1,12 @@
+import dataclasses
 import logging
 
 from flask import Flask, jsonify, request
 
-from tielian.block import create_genesis_block, load_block
-from tielian.transaction import create_transaction_from_json, trim_pending_txs
+from tielian.block import Block, create_genesis_block
+from tielian.transaction import Transaction
 
-app = Flask('TIELIE_RPC_v1')
+app = Flask('TIELIAN_RPC_v1')
 
 # 待定交易列表，新提交的交易会被加入到该列表内
 pending_txs = []
@@ -21,7 +22,7 @@ def submit_tx():
     交易将被加入到待打包交易
     """
     payload = request.get_json()
-    tx = create_transaction_from_json(payload)
+    tx = Transaction(**payload)
 
     # 将交易放入待打包交易
     pending_txs.append(tx)
@@ -29,56 +30,56 @@ def submit_tx():
     logging.info('收到新交易：%s，当前待定交易数量：%d', tx, len(pending_txs))
 
     return jsonify(
-        result=tx.to_json(),
+        result=dataclasses.asdict(tx),
         msg='铁链本节点成功收到交易',
     ), 201
 
 
 @app.route('/txs', methods=['GET'])
 def get_pending_txs():
-    txs = list(map(lambda x: x.to_json(), pending_txs))
+    """ 获取待打包交易 """
+    txs = list(map(lambda tx: dataclasses.asdict(tx), pending_txs))
     return jsonify(txs)
 
 
 @app.route('/blocks', methods=['POST'])
 def submit_block():
-    """
-    提交已打包新区块
-    """
+    """ 提交已打包新区块 """
     global pending_txs
-
-    block = load_block(request.get_json())
+    payload = request.get_json()
+    block = Block(**payload)
 
     try:
         current_block = chain[-1]
         block.is_valid(current_block)
-    except Exception as e:
-        raise Exception('非法区块尝试上链！%s' % e)
+    except Exception as ex:
+        raise Exception(f'非法区块尝试上链！{ex}')
 
     # 把已经打包的交易从待打包交易去掉
-    pending_txs = trim_pending_txs(pending_txs, block)
+    # TODO: 可以优化这一步
+    pending_txs = list(filter(lambda tx: tx in block.txs, pending_txs))
 
     chain.append(block)
-    return "", 201
+    return '', 201
 
 
 @app.route('/blocks', methods=['GET'])
 def get_all_blocks():
-    """
-    获取所有区块
-    """
-    blocks = list(map(lambda x: x.to_json(), chain))
+    """ 获取所有区块 """
+    blocks = list(map(lambda x: dataclasses.asdict(x), chain))
     return jsonify(blocks=blocks)
 
 
 @app.route('/blocks/latest', methods=['GET'])
 def get_latest_block():
-    return jsonify(block=chain[-1].to_json())
+    """ 获取最近得到的区块 """
+    return jsonify(block=dataclasses.asdict(chain[-1]))
 
 
 @app.errorhandler(Exception)
-def error_handler(e):
-    return jsonify(msg=str(e)), 500
+def error_handler(ex):
+    logging.exception(ex)
+    return jsonify(msg=str(ex)), 500
 
 
 if __name__ == '__main__':

--- a/tielian/transaction.py
+++ b/tielian/transaction.py
@@ -1,52 +1,22 @@
+import dataclasses
+
+
+@dataclasses.dataclass
 class Transaction:
-    """
-    交易
-    """
-
-    def __init__(self, _from, _to, _value):
-        self.sender = _from
-        self.to = _to
-        self.value = _value
-
-    def to_json(self):
-        return {
-            'sender': self.sender,
-            'to': self.to,
-            'value': self.value
-        }
-
-    def __str__(self):
-        return 'Transaction<sender=%s, to=%s, value=%s>' % (self.sender, self.to, self.value)
-
-
-def _create_transaction_from_json(payload):
-    return Transaction(payload['sender'], payload['to'], payload['value'])
+    """ 交易 """
+    sender: str
+    to: str
+    value: str
 
 
 def create_transaction_from_json(payload):
-    """
-    将传入的JSON转化成交易对象，若JSON是列表，就返回一个交易对象列表
-    """
-    if type(payload) is list:
-        return [_create_transaction_from_json(obj) for obj in payload]
-    elif type(payload) is dict:
-        return _create_transaction_from_json(payload)
+    """ 将传入的JSON转化成交易对象，若JSON是列表，就返回一个交易对象列表 """
+    if isinstance(payload, list):
+        return [create_transaction_from_json(_) for _ in payload]
+    elif isinstance(payload, dict):
+        return Transaction(**payload)
     else:
         raise Exception('错误的负载类型')
-
-
-def dump_transactions(txs):
-    return [tx.to_json() for tx in txs]
-
-
-def _contains_tx(tx, txs):
-    """
-    判断 txs 是否包含 tx
-    """
-    for t in txs:
-        if t.sender == tx.sender and t.to == tx.to and t.value == tx.value:
-            return True
-    return False
 
 
 def trim_pending_txs(pending_txs, block):
@@ -55,6 +25,7 @@ def trim_pending_txs(pending_txs, block):
 
     现在的时间复杂度是 O(n^2)，因为要同时遍历 pending_txs 和 block 中的交易
     """
+    # TODO 考虑 tx 加入 timestamp
     block_txs = block.txs
 
-    return list(filter(lambda tx: _contains_tx(tx, block_txs), pending_txs))
+    return list(filter(lambda tx: tx in block_txs, pending_txs))

--- a/tielian/transaction.py
+++ b/tielian/transaction.py
@@ -8,13 +8,3 @@ class Transaction:
     to: str
     value: str
     # TODO 考虑 tx 加入 timestamp
-
-
-def create_transaction_from_json(payload):
-    """ 将传入的JSON转化成交易对象，若JSON是列表，就返回一个交易对象列表 """
-    if isinstance(payload, list):
-        return [create_transaction_from_json(_) for _ in payload]
-    elif isinstance(payload, dict):
-        return Transaction(**payload)
-    else:
-        raise Exception('错误的负载类型')

--- a/tielian/transaction.py
+++ b/tielian/transaction.py
@@ -7,6 +7,7 @@ class Transaction:
     sender: str
     to: str
     value: str
+    # TODO 考虑 tx 加入 timestamp
 
 
 def create_transaction_from_json(payload):
@@ -17,15 +18,3 @@ def create_transaction_from_json(payload):
         return Transaction(**payload)
     else:
         raise Exception('错误的负载类型')
-
-
-def trim_pending_txs(pending_txs, block):
-    """
-    将已经打包的交易从待打包交易去掉
-
-    现在的时间复杂度是 O(n^2)，因为要同时遍历 pending_txs 和 block 中的交易
-    """
-    # TODO 考虑 tx 加入 timestamp
-    block_txs = block.txs
-
-    return list(filter(lambda tx: tx in block_txs, pending_txs))

--- a/tielian/transaction.py
+++ b/tielian/transaction.py
@@ -22,6 +22,7 @@ class Transaction:
 def _create_transaction_from_json(payload):
     return Transaction(payload['sender'], payload['to'], payload['value'])
 
+
 def create_transaction_from_json(payload):
     """
     将传入的JSON转化成交易对象，若JSON是列表，就返回一个交易对象列表
@@ -32,6 +33,7 @@ def create_transaction_from_json(payload):
         return _create_transaction_from_json(payload)
     else:
         raise Exception('错误的负载类型')
+
 
 def dump_transactions(txs):
     return [tx.to_json() for tx in txs]
@@ -45,6 +47,7 @@ def _contains_tx(tx, txs):
         if t.sender == tx.sender and t.to == tx.to and t.value == tx.value:
             return True
     return False
+
 
 def trim_pending_txs(pending_txs, block):
     """


### PR DESCRIPTION
项目骨架和逻辑没有变动，本 PR 为纯重构，改动主要包括以下内容：

- 更新了 Pipfile，使用了 aliyun 源和 python 3.7
- 利用 Python 3.7 的 [dataclasses](https://docs.python.org/3/library/dataclasses.html) 特性
  - object to dict: `payload = dataclasses.as_dict(block)`
  - dict to object: `block = Block(**payload)`
  - 重构并移除了现有的序列化代码
- 利用 typing 系统统一了部分类型
  - Block.timestamp 现在是 unix 时间戳而非 python datetime 了
  - Block.data 现在是 dict 类型
- 一些小的地方调整了一下
  - 统一使用了单引号
  - 使用了 f-string 来做字符串表示